### PR TITLE
Add Microsoft's clipboard format for secrets

### DIFF
--- a/src/Clipboard.cpp
+++ b/src/Clipboard.cpp
@@ -28,6 +28,8 @@ void Clipboard::makeSecret() const {
     if (_options.secret) {
         UINT CF_CLIPBOARD_VIEWER_IGNORE = RegisterClipboardFormat("Clipboard Viewer Ignore");
         SetClipboardData(CF_CLIPBOARD_VIEWER_IGNORE, nullptr);
+        UINT CF_CLIPBOARD_MONITOR_EXLUDE = RegisterClipboardFormat("ExcludeClipboardContentFromMonitorProcessing");
+        SetClipboardData(CF_CLIPBOARD_MONITOR_EXLUDE, nullptr);
     }
 }
 


### PR DESCRIPTION
Serving the same purpose as `Clipboard Viewer Ignore`, Microsoft defines `ExcludeClipboardContentFromMonitorProcessing`:

> Place any data on the clipboard in this format to prevent all
> clipboard formats being included in the clipboard history
> or synchronized to the user's other devices.

Per [Cloud Clipboard and Clipboard History Formats](https://learn.microsoft.com/en-us/windows/win32/dataxchg/clipboard-formats#cloud-clipboard-and-clipboard-history-formats)